### PR TITLE
Feature/parse failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,44 @@ Main features:
 
 ## Installation
 
-For now, the only supported way is to build the binary yourself. This requires at least version 1.20 of the `go` cli.
+### Binary download
+
+- Head over to the releases page ([https://github.com/QuintenBruynseraede/tf-profile/releases](https://github.com/QuintenBruynseraede/tf-profile/releases)) 
+- Download the correct binary for your operating system
+- Copy it to a path that is on your `$PATH`. On a Linux system, `/usr/local/bin` is the most common location.
+
+### Using docker
+
+If you want to try `tf-profile` without installing anything, you can run it using Docker (or similar).
 
 ```bash
-$ git clone git@github.com:QuintenBruynseraede/tf-profile.git
-$ cd tf-profile && go build .
-$ sudo ln -s $(pwd)/tf-profile /usr/local/bin  # Optional: only if you want to run tf-profile from other directories
-$ tf-profile --help
+❱ cat my_log_file.log | docker run -i qbruynseraede/tf-profile:0.0.1 stats
+
+Key                                Value                                     
+Number of resources created        1510                                      
+                                                                             
+Cumulative duration                36m19s                                    
+Longest apply time                 7m18s                                     
+Longest apply resource             time_sleep.foo[*]                         
+...
+```
+
+Optionally, define an alias:
+
+```bash
+❱ alias tf-profile=docker run -i qbruynseraede/tf-profile:0.0.1
+❱ cat my_log_file.log | tf-profile
+```
+
+### Build from source
+
+This requires at least version 1.20 of the `go` cli.
+
+```bash
+❱ git clone git@github.com:QuintenBruynseraede/tf-profile.git
+❱ cd tf-profile && go build .
+❱ sudo ln -s $(pwd)/tf-profile /usr/local/bin  # Optional: only if you want to run tf-profile from other directories
+❱ tf-profile --help
 tf-profile is a CLI tool to profile Terraform runs
 
 Usage:
@@ -30,8 +61,8 @@ Usage:
 `tf-profile` handles input from stdin and from files. These two commands are therefore equivalent:
 
 ```bash
-$ terraform apply -auto-approve | tf-profile table
-$ terraform apply -auto-approve > log.txt && tf-profile table log.txt
+❱ terraform apply -auto-approve | tf-profile table
+❱ terraform apply -auto-approve > log.txt && tf-profile table log.txt
 ```
 
 Three major commands are supported:
@@ -46,9 +77,9 @@ Three major commands are supported:
 `tf-profile stats` is the most basic command. Given a Terraform log, it will only provide high-level statistics.
 
 ```bash
-$ terraform apply -auto-approve > log.txt
-$ tf-profile stats log.txt
-> tf-profile stats test/many_modules.log
+❱ terraform apply -auto-approve > log.txt
+❱ tf-profile stats log.txt
+❱ tf-profile stats test/many_modules.log
 
 Key                                Value    
 -----------------------------------------------------------------                       
@@ -84,8 +115,8 @@ Size of largest leaf module        40
    
     With resource aggregation, more informative statuses have precedence over less informative statuses. For example, `AllCreated` will be shown over `AllStarted`.
 ```bash
-$ terraform apply -auto-approve > log.txt
-$ tf-profile table log.txt
+❱ terraform apply -auto-approve > log.txt
+❱ tf-profile table log.txt
 
 resource                            n  tot_time  idx_creation  idx_created  status    
 -------------------------------------------------------------------------------------- 
@@ -102,15 +133,9 @@ Entries in this table can be sorted by providing a `--sort` (shorthand `-s`) arg
 - `tot_time=asc,resource=desc,status=asc`: sort by total time, resource name and creation status in that order
 
 ```bash
-$ terraform apply -auto-approve > log.txt
-$ tf-profile table --sort "tot_time=asc,resource=desc" log.txt
-
-resource                            n  tot_time  idx_creation  idx_created  status      
---------------------------------------------------------------------------------------
-module.test[0].time_sleep.count[*]  3  4000      9             7            AllCreated  
-module.test[1].time_sleep.count[*]  3  5000      3             9            AllCreated  
-time_sleep.foreach[*]               3  7000      4             11           AllCreated  
-time_sleep.count[*]                 5  11000     0             13           AllCreated 
+❱ terraform apply -auto-approve > log.txt
+❱ tf-profile table --sort "tot_time=asc,resource=desc" log.txt
+❱ tf-profile table --sort "n=desc,index_creation=desc" log.txt
 ```
 
 ### Mirroring input with `--tee`
@@ -119,7 +144,7 @@ When piping stdinput into `tf-profile`, it is convenient to use the `--tee` flag
 
 Example:
 ```bash
-$ terraform apply -auto-approve | tf-profile table --tee
+❱ terraform apply -auto-approve | tf-profile table --tee
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
@@ -129,13 +154,7 @@ Terraform will perform the following actions:
 
   # aws_subnet.test[0] will be created
   ...
-
-resource                            n  tot_time  idx_creation  idx_created  status    
--------------------------------------------------------------------------------------- 
-time_sleep.count[*]                 5  11000     0             13           AllCreated  
-time_sleep.foreach[*]               3  7000      4             11           AllCreated  
-module.test[1].time_sleep.count[*]  3  5000      3             9            AllCreated  
-module.test[0].time_sleep.count[*]  3  4000      9             7            AllCreated 
+  < result of tf-profile will appear after the logs>
 ```
 
 ### Limit output with `--max_depth`
@@ -144,7 +163,7 @@ module.test[0].time_sleep.count[*]  3  4000      9             7            AllC
 When working with a large codebase, viewing statistics for every resource may be too detailed. You can limit the maximum module depth that `tf-profile` parses with `--max_depth` (default: -1, no limit). Any nested modules deeper than `--max_depth` are simply shown as their module name. Statistics of resources within that module are aggregated.
 
 ```bash
-$ terraform apply -auto-approve | tf-profile table --max_depth 1 --tee
+❱ terraform apply -auto-approve | tf-profile table --max_depth 1 --tee
 
 resource                            n  tot_time  idx_creation  idx_created  status    
 -------------------------------------------------------------------------------------- 
@@ -163,3 +182,11 @@ module.test[0]                      3  4000      9             7            AllC
 ![stats.png](https://github.com/QuintenBruynseraede/tf-profile/blob/main/.github/stats.png?raw=true)
 
 ![table.png](https://github.com/QuintenBruynseraede/tf-profile/blob/main/.github/table.png?raw=true)
+
+## Roadmap
+
+- [x] Release v0.0.1 as binary and as a Docker image
+- [ ] Improve parser
+  - [ ] Detect failed resources
+  - [ ] Use plan and refresh phase to discover more resources
+- [ ] Implement a basic [flame graph](https://github.com/brendangregg/FlameGraph) in `tf-profile graph`

--- a/pkg/tf-profile/core/fmt_utils.go
+++ b/pkg/tf-profile/core/fmt_utils.go
@@ -1,0 +1,17 @@
+package tfprofile
+
+import (
+	"fmt"
+	"time"
+)
+
+// Format a duration in seconds into "30s" or "2m30s"
+func FormatDuration(seconds int) string {
+	duration := time.Duration(seconds) * time.Second
+	minutes := int(duration.Minutes())
+	seconds = seconds - (minutes * 60)
+	if minutes == 0 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	return fmt.Sprintf("%dm%ds", minutes, seconds)
+}

--- a/pkg/tf-profile/core/parser_test.go
+++ b/pkg/tf-profile/core/parser_test.go
@@ -66,3 +66,33 @@ func TestFullParse(t *testing.T) {
 		t.Fatalf("Expected %v, got %v\n", expected2, metrics2)
 	}
 }
+
+func TestFailureParseLine(t *testing.T) {
+	r, err := ParseCreationFailed(" with aws_ssm_parameter.bad2[0],  ")
+	assert.Nil(t, err)
+	assert.Equal(t, "aws_ssm_parameter.bad2[0]", r)
+}
+
+func TestFailureParse(t *testing.T) {
+	file, _ := os.Open("../../../test/failures.log")
+	s := bufio.NewScanner(file)
+
+	log, err := Parse(s, false)
+	assert.Nil(t, err)
+
+	metrics, exists := log.Resources["aws_ssm_parameter.good2[0]"]
+	assert.True(t, exists)
+	assert.Equal(t, metrics.CreationStatus, Created)
+
+	metrics, exists = log.Resources["aws_ssm_parameter.good"]
+	assert.True(t, exists)
+	assert.Equal(t, metrics.CreationStatus, Created)
+
+	metrics, exists = log.Resources["aws_ssm_parameter.bad2[1]"]
+	assert.True(t, exists)
+	assert.Equal(t, metrics.CreationStatus, Failed)
+
+	metrics, exists = log.Resources["aws_ssm_parameter.bad"]
+	assert.True(t, exists)
+	assert.Equal(t, metrics.CreationStatus, Failed)
+}

--- a/pkg/tf-profile/stats/resource_utils.go
+++ b/pkg/tf-profile/stats/resource_utils.go
@@ -1,9 +1,7 @@
 package tfprofile
 
 import (
-	"fmt"
 	"strings"
-	"time"
 )
 
 // Extract the top level module.
@@ -26,17 +24,6 @@ func getTopLevelModule(name string) string {
 func getModuleDepth(name string) int {
 	tokens := len(strings.Split(name, "."))
 	return (tokens - 2) / 2
-}
-
-// Format a duration in seconds into "30s" or "2m30s"
-func formatDuration(seconds int) string {
-	duration := time.Duration(seconds) * time.Second
-	minutes := int(duration.Minutes())
-	seconds = seconds - (minutes * 60)
-	if minutes == 0 {
-		return fmt.Sprintf("%ds", seconds)
-	}
-	return fmt.Sprintf("%dm%ds", minutes, seconds)
 }
 
 // Given a full resource name, return the name of the deepest module it belongs to

--- a/pkg/tf-profile/stats/stats.go
+++ b/pkg/tf-profile/stats/stats.go
@@ -80,7 +80,7 @@ func GetBasicStats(log ParsedLog) []Stat {
 		NumCalls += resource.NumCalls
 	}
 	return []Stat{
-		Stat{"Number of resources created", fmt.Sprint(NumCalls)},
+		Stat{"Number of resources in configuration", fmt.Sprint(NumCalls)},
 	}
 }
 
@@ -97,8 +97,8 @@ func GetTimeStats(log ParsedLog) []Stat {
 		}
 	}
 	return []Stat{
-		Stat{"Cumulative duration", formatDuration(TotalTime)},
-		Stat{"Longest apply time", formatDuration(HighestTime / 1000)},
+		Stat{"Cumulative duration", FormatDuration(TotalTime)},
+		Stat{"Longest apply time", FormatDuration(HighestTime / 1000)},
 		Stat{"Longest apply resource", HighestResource},
 	}
 }

--- a/pkg/tf-profile/stats/stats_test.go
+++ b/pkg/tf-profile/stats/stats_test.go
@@ -18,7 +18,7 @@ func TestBasicStats(t *testing.T) {
 	}
 	Out := GetBasicStats(In)
 	assert.Equal(t, 1, len(Out))
-	assert.Equal(t, "Number of resources created", Out[0].name)
+	assert.Equal(t, "Number of resources in configuration", Out[0].name)
 	assert.Equal(t, "4", Out[0].value)
 }
 

--- a/pkg/tf-profile/table/table.go
+++ b/pkg/tf-profile/table/table.go
@@ -58,9 +58,9 @@ func PrintTable(log ParsedLog, sort_spec string) error {
 				tbl.AddRow(
 					resource,
 					(metric.NumCalls),
-					(metric.TotalTime),
-					(metric.CreationStartedIndex),
-					(metric.CreationCompletedIndex),
+					FormatDuration(int(metric.TotalTime/1000)), // Display as "10s" or "1m30s"
+					removeMinusOne(metric.CreationStartedIndex),
+					removeMinusOne(metric.CreationCompletedIndex),
 					(metric.CreationStatus),
 				)
 				break
@@ -72,4 +72,14 @@ func PrintTable(log ParsedLog, sort_spec string) error {
 	tbl.Print()
 
 	return nil
+}
+
+// Many metrics use -1 as value for "unknown at the time". When a resource change fails,
+// these initial values remain in the log. Before printing, we replace then with '/'
+func removeMinusOne(val int) string {
+	if val == -1 {
+		return "/"
+	} else {
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/test/failures.log
+++ b/test/failures.log
@@ -1,0 +1,172 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # aws_ssm_parameter.bad will be created
+  + resource "aws_ssm_parameter" "bad" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[0] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end0/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[1] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end1/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[2] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end2/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.good will be created
+  + resource "aws_ssm_parameter" "good" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/no/slash/at/end"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.good2[0] will be created
+  + resource "aws_ssm_parameter" "good2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/no/slash/at/end0"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.good2[1] will be created
+  + resource "aws_ssm_parameter" "good2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/no/slash/at/end1"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.good2[2] will be created
+  + resource "aws_ssm_parameter" "good2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/no/slash/at/end2"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+Plan: 8 to add, 0 to change, 0 to destroy.
+aws_ssm_parameter.good: Creating...
+aws_ssm_parameter.bad2[2]: Creating...
+aws_ssm_parameter.bad2[1]: Creating...
+aws_ssm_parameter.bad2[0]: Creating...
+aws_ssm_parameter.good2[1]: Creating...
+aws_ssm_parameter.bad: Creating...
+aws_ssm_parameter.good2[2]: Creating...
+aws_ssm_parameter.good2[0]: Creating...
+aws_ssm_parameter.good: Creation complete after 1s [id=/no/slash/at/end]
+aws_ssm_parameter.good2[0]: Creation complete after 1s [id=/no/slash/at/end0]
+aws_ssm_parameter.good2[2]: Creation complete after 1s [id=/no/slash/at/end2]
+aws_ssm_parameter.good2[1]: Creation complete after 1s [id=/no/slash/at/end1]
+
+Error: creating SSM Parameter (/slash/at/end/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 99b72eaf-10ec-49d7-99e4-bc960809383e
+
+  with aws_ssm_parameter.bad,
+  on provider.tf line 15, in resource "aws_ssm_parameter" "bad":
+  15: resource "aws_ssm_parameter" "bad" {
+
+
+Error: creating SSM Parameter (/slash/at/end2/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 99a3ae5f-9d97-4bc9-bfd8-ac29b72fc00d
+
+  with aws_ssm_parameter.bad2[2],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+
+
+Error: creating SSM Parameter (/slash/at/end1/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 77765932-a8b2-48bf-abe2-71a151da56ea
+
+  with aws_ssm_parameter.bad2[1],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+
+
+Error: creating SSM Parameter (/slash/at/end0/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: f78b2744-2fff-4df9-824b-ba7c40ab256a
+
+  with aws_ssm_parameter.bad2[0],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+

--- a/test/failures/provider.tf
+++ b/test/failures/provider.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_ssm_parameter" "bad" {
+  name  = "/slash/at/end/"
+  type  = "String"
+  value = "test"
+}
+
+resource "aws_ssm_parameter" "good" {
+  name  = "/no/slash/at/end"
+  type  = "String"
+  value = "test"
+}
+
+resource "aws_ssm_parameter" "bad2" {
+  count = 3
+  name  = "/slash/at/end${count.index}/"
+  type  = "String"
+  value = "test"
+}
+
+resource "aws_ssm_parameter" "good2" {
+  count = 3
+  name  = "/no/slash/at/end${count.index}"
+  type  = "String"
+  value = "test"
+}

--- a/test/only_failures.log
+++ b/test/only_failures.log
@@ -1,0 +1,105 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # aws_ssm_parameter.bad will be created
+  + resource "aws_ssm_parameter" "bad" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[0] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end0/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[1] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end1/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+  # aws_ssm_parameter.bad2[2] will be created
+  + resource "aws_ssm_parameter" "bad2" {
+      + arn            = (known after apply)
+      + data_type      = (known after apply)
+      + id             = (known after apply)
+      + insecure_value = (known after apply)
+      + key_id         = (known after apply)
+      + name           = "/slash/at/end2/"
+      + tags_all       = (known after apply)
+      + tier           = (known after apply)
+      + type           = "String"
+      + value          = (sensitive value)
+      + version        = (known after apply)
+    }
+
+
+Plan: 4 to add, 0 to change, 0 to destroy.
+aws_ssm_parameter.bad2[2]: Creating...
+aws_ssm_parameter.bad2[1]: Creating...
+aws_ssm_parameter.bad2[0]: Creating...
+aws_ssm_parameter.bad: Creating...
+
+Error: creating SSM Parameter (/slash/at/end/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 99b72eaf-10ec-49d7-99e4-bc960809383e
+
+  with aws_ssm_parameter.bad,
+  on provider.tf line 15, in resource "aws_ssm_parameter" "bad":
+  15: resource "aws_ssm_parameter" "bad" {
+
+
+Error: creating SSM Parameter (/slash/at/end2/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 99a3ae5f-9d97-4bc9-bfd8-ac29b72fc00d
+
+  with aws_ssm_parameter.bad2[2],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+
+
+Error: creating SSM Parameter (/slash/at/end1/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: 77765932-a8b2-48bf-abe2-71a151da56ea
+
+  with aws_ssm_parameter.bad2[1],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+
+
+Error: creating SSM Parameter (/slash/at/end0/): ValidationException: Parameter name must not end with slash.
+	status code: 400, request id: f78b2744-2fff-4df9-824b-ba7c40ab256a
+
+  with aws_ssm_parameter.bad2[0],
+  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
+  27: resource "aws_ssm_parameter" "bad2" {
+


### PR DESCRIPTION
This PR implement correct parsing of resource whose deletion/creation/update failed at apply time.

For instance, the following log indicates an error when creating `aws_ssm_parameter.bad2[0]`:
```
Error: creating SSM Parameter (/slash/at/end0/): ValidationException: Parameter name must not end with slash.
	status code: 400, request id: f78b2744-2fff-4df9-824b-ba7c40ab256a

  with aws_ssm_parameter.bad2[0],
  on provider.tf line 27, in resource "aws_ssm_parameter" "bad2":
  27: resource "aws_ssm_parameter" "bad2" {
```

The Parser now support these logs and will correctly set the resource status to "Failed"

```
resource                    n  tot_time    idx_creation  idx_created  status      
aws_ssm_parameter.good2[*]  3  3s          7             3             AllCreated  
aws_ssm_parameter.good      1  1s          0             0             Created     
aws_ssm_parameter.bad       1  0s          5             /             Failed      
aws_ssm_parameter.bad2[*]   3  0s          3             /             AllFailed   
```

In addition, the `stats` and `print` command have been adapted to show "/" instead of -1.